### PR TITLE
refactor: Update stock management to use ProductVariant

### DIFF
--- a/storeApp/models.py
+++ b/storeApp/models.py
@@ -121,7 +121,7 @@ class Order(BaseModel):
 class OrderItem(BaseModel):
     """Chi tiết đơn hàng"""
     order = models.ForeignKey(Order, on_delete=models.CASCADE, related_name='items', db_column='order_id')
-    product_variant = models.ForeignKey('ProductVariant', on_delete=models.PROTECT, related_name='order_items', db_column='product_variant_id', null=True)
+    product_variant = models.ForeignKey('ProductVariant', on_delete=models.PROTECT, related_name='order_items', db_column='product_variant_id')
     quantity = models.PositiveIntegerField(null=False, validators=[MinValueValidator(1)], db_column='quantity')
     price = models.FloatField(null=False, validators=[MinValueValidator(0)], db_column='price', help_text="Giá tại thời điểm đặt hàng (snapshot)")
 
@@ -144,13 +144,15 @@ class OrderItem(BaseModel):
 class MedicineBatch(BaseModel):
     """Quản lý lô thuốc - theo dõi ngày nhập và hạn sử dụng"""
     batch_number = models.CharField(max_length=100, null=False, blank=False, unique=True, db_index=True, db_column='batch_number', help_text="Mã lô thuốc")
-    product_variant = models.ForeignKey('ProductVariant', on_delete=models.PROTECT, related_name='batches', db_column='product_variant_id', null=True)
+    product_variant = models.ForeignKey('ProductVariant', on_delete=models.PROTECT, related_name='batches', db_column='product_variant_id')
+    
     import_date = models.DateField(null=False, db_column='import_date', help_text="Ngày nhập kho")
     expiry_date = models.DateField(null=False, db_column='expiry_date', help_text="Hạn sử dụng")
-    quantity = models.PositiveIntegerField(null=False, validators=[MinValueValidator(1)], db_column='quantity', help_text="Số lượng nhập")
-    remaining_quantity = models.PositiveIntegerField(null=False, default=0, db_column='remaining_quantity', help_text="Số lượng còn lại")
-    import_price = models.FloatField(null=True, blank=True, validators=[MinValueValidator(0)], db_column='import_price', help_text="Giá nhập kho (để tính lợi nhuận)")
-
+    
+    quantity = models.PositiveIntegerField(null=False, validators=[MinValueValidator(1)], db_column='quantity', help_text="Số lượng nhập theo đơn vị cơ sở")
+    remaining_quantity = models.PositiveIntegerField(null=False, default=0, db_column='remaining_quantity', help_text="Số lượng còn lại theo đơn vị cơ sở")
+    import_price_per_base_unit = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True, validators=[MinValueValidator(0)])
+    
     def __str__(self):
         return f"Batch {self.batch_number} - Exp: {self.expiry_date}"
 
@@ -353,6 +355,11 @@ class Product(BaseModel):
     careful = models.TextField(null=True, blank=True)
     preservation = models.TextField(null=True, blank=True)
     
+    origin = models.CharField(max_length=200, null=True, blank=True)
+    manufacturer = models.TextField(null=True, blank=True)
+    shelf_life = models.CharField(max_length=100, null=True, blank=True)
+    specifications = models.JSONField(default=dict, null=True, blank=True)
+    
     brand = models.ForeignKey(Brand, on_delete=models.SET_NULL, null=True, blank=True, related_name='products')
     category = models.ForeignKey(Category, on_delete=models.SET_NULL, null=True, blank=True, related_name='products')
 
@@ -372,27 +379,23 @@ class Product(BaseModel):
 
 class ProductVariant(BaseModel):
     product = models.ForeignKey(Product, on_delete=models.CASCADE, related_name='variants', db_index=True)
+    sku = models.CharField(max_length=100, null=True, blank=True, unique=True, db_index=True, help_text="Stock Keeping Unit")
+
     packing = models.CharField(max_length=100, null=True, blank=True, help_text="Quy cách đóng gói, ví dụ: Hộp 30 viên")
-    in_stock = models.IntegerField(null=False, default=0, db_index=True)
-    
-    price_display = models.CharField(max_length=50, null=True, blank=True)
-    price_value = models.FloatField(null=False, default=0, db_index=True)
+    packing_meta = models.JSONField(default=dict, blank=True)
     
     image = CloudinaryField('products', default='', null=True, folder='OUPharmacy/products/image')
     images = models.JSONField(default=list, blank=True)
-    
+
     registration_number = models.CharField(max_length=100, null=True, blank=True)
-    origin = models.CharField(max_length=200, null=True, blank=True)
-    manufacturer = models.TextField(null=True, blank=True)
-    shelf_life = models.CharField(max_length=100, null=True, blank=True)
-    specifications = models.JSONField(default=dict, null=True, blank=True)
+    base_unit = models.CharField(max_length=50, null=True, blank=True, db_index=True, help_text="Đơn vị cơ sở nhỏ nhất, ví dụ: viên, gói")
     
+    in_stock = models.IntegerField(null=False, default=0, db_index=True, help_text="Tồn kho cache theo đơn vị cơ sở (base unit)")
     product_ranking = models.IntegerField(default=0, db_index=True)
-    display_code = models.IntegerField(null=True, blank=True)
+    
     is_published = models.BooleanField(default=True, db_index=True)
     is_hot = models.BooleanField(default=False, db_index=True)
-    is_default = models.BooleanField(default=True, db_index=True)
-
+ 
     def __str__(self):
         return f"{self.product.name} - {self.packing}"
 
@@ -412,10 +415,26 @@ class ProductVariant(BaseModel):
         verbose_name_plural = 'Product Variants'
         indexes = [
             models.Index(fields=['is_published', 'product_ranking']),
-            models.Index(fields=['price_value', 'is_published']),
             models.Index(fields=['is_hot', 'is_published']),
         ]
 
+class ProductVariantUnit(BaseModel):
+    variant = models.ForeignKey(ProductVariant, on_delete=models.CASCADE, related_name='units', db_column='product_variant_id')
+    quantity_in_base = models.PositiveIntegerField(default=1, help_text="1 Hộp = 30 viên, 1 Vỉ = 10 viên")
+    
+    unit_name = models.CharField(max_length=50, db_index=True, help_text="Hộp, Vỉ, Viên, Gói...")
+    unit_order = models.PositiveIntegerField(default=0)
+    
+    price_value = models.DecimalField(max_digits=12, decimal_places=2, default=0)
+    price_display = models.CharField(max_length=50, null=True, blank=True)
+
+    compare_at_price = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
+    is_default = models.BooleanField(default=False, db_index=True)
+    is_published = models.BooleanField(default=True, db_index=True)
+
+    class Meta:
+        unique_together = [('variant', 'unit_name')]
+        ordering = ['unit_order', 'id']
 
 class ProductVariantStats(models.Model):
     variant = models.OneToOneField(ProductVariant, on_delete=models.CASCADE, related_name='stats')

--- a/storeApp/services/stock.py
+++ b/storeApp/services/stock.py
@@ -1,28 +1,27 @@
 """
 Stock service: single source of truth = Batches (store DB).
-- get_available_stock(medicine_unit_id)
-- deduct_stock(medicine_unit_id, quantity)  # FIFO on batches, then sync cache
-- restore_stock(medicine_unit_id, quantity)  # LIFO restore into nearest-expiry batch or create ADJ batch
-- sync_in_stock_cache(medicine_unit_id)      # Update MedicineUnit.in_stock from batch sum
+- get_available_stock(product_variant_id)
+- deduct_stock(product_variant_id, quantity)  # FIFO on batches, then sync cache
+- restore_stock(product_variant_id, quantity)  # LIFO restore into nearest-expiry batch or create ADJ batch
+- sync_in_stock_cache(product_variant_id)      # Update ProductVariant.in_stock from batch sum
 """
 from django.db import transaction, models
 from django.utils import timezone
 from dateutil.relativedelta import relativedelta
 
-from mainApp.models import MedicineUnit
-from storeApp.models import MedicineBatch
+from storeApp.models import MedicineBatch, ProductVariant
 
 
-def get_available_stock(medicine_unit_id):
+def get_available_stock(product_variant_id):
     """
     Sum remaining_quantity from Batches (store): active, remaining_quantity > 0, expiry_date >= today.
-    Fallback: if no such batches, return MedicineUnit.in_stock (default DB).
+    Fallback: if no such batches, return ProductVariant.in_stock.
     """
     today = timezone.now().date()
     total = (
         MedicineBatch.objects.using('store')
         .filter(
-            medicine_unit_id=medicine_unit_id,
+            product_variant_id=product_variant_id,
             active=True,
             remaining_quantity__gt=0,
             expiry_date__gte=today,
@@ -32,16 +31,16 @@ def get_available_stock(medicine_unit_id):
     if total is not None:
         return int(total)
     try:
-        unit = MedicineUnit.objects.using('default').get(id=medicine_unit_id)
-        return getattr(unit, 'in_stock', 0) or 0
-    except MedicineUnit.DoesNotExist:
+        variant = ProductVariant.objects.using('store').get(id=product_variant_id)
+        return getattr(variant, 'in_stock', 0) or 0
+    except ProductVariant.DoesNotExist:
         return 0
 
 
-def deduct_stock(medicine_unit_id, quantity):
+def deduct_stock(product_variant_id, quantity):
     """
     Deduct quantity from batches (store) FIFO. Raise ValueError if insufficient.
-    Then sync MedicineUnit.in_stock cache (default DB).
+    Then sync ProductVariant.in_stock cache.
     """
     if quantity <= 0:
         return
@@ -49,7 +48,7 @@ def deduct_stock(medicine_unit_id, quantity):
     batches = list(
         MedicineBatch.objects.using('store')
         .filter(
-            medicine_unit_id=medicine_unit_id,
+            product_variant_id=product_variant_id,
             active=True,
             remaining_quantity__gt=0,
             expiry_date__gte=today,
@@ -70,16 +69,16 @@ def deduct_stock(medicine_unit_id, quantity):
             batch.save(update_fields=['remaining_quantity'])
     if remaining > 0:
         raise ValueError(
-            f'Insufficient stock for medicine_unit_id {medicine_unit_id}. Could not deduct {remaining} units.'
+            f'Insufficient stock for product_variant_id {product_variant_id}. Could not deduct {remaining} units.'
         )
-    sync_in_stock_cache(medicine_unit_id)
+    sync_in_stock_cache(product_variant_id)
 
 
-def restore_stock(medicine_unit_id, quantity):
+def restore_stock(product_variant_id, quantity):
     """
     Restore quantity: add to the batch with nearest expiry (LIFO restore).
-    If no suitable batch, create an adjustment batch (ADJ-{unit_id}-{timestamp}).
-    Then sync MedicineUnit.in_stock cache.
+    If no suitable batch, create an adjustment batch (ADJ-{variant_id}-{timestamp}).
+    Then sync ProductVariant.in_stock cache.
     """
     if quantity <= 0:
         return
@@ -87,7 +86,7 @@ def restore_stock(medicine_unit_id, quantity):
     batches = list(
         MedicineBatch.objects.using('store')
         .filter(
-            medicine_unit_id=medicine_unit_id,
+            product_variant_id=product_variant_id,
             active=True,
             expiry_date__gte=today,
         )
@@ -101,11 +100,11 @@ def restore_stock(medicine_unit_id, quantity):
     else:
         # No batch to restore into: create adjustment batch
         ts = timezone.now().strftime('%Y%m%d%H%M%S')
-        batch_number = f'ADJ-{medicine_unit_id}-{ts}'
+        batch_number = f'ADJ-{product_variant_id}-{ts}'
         expiry_date = today + relativedelta(months=12)
         MedicineBatch.objects.using('store').create(
             batch_number=batch_number,
-            medicine_unit_id=medicine_unit_id,
+            product_variant_id=product_variant_id,
             import_date=today,
             expiry_date=expiry_date,
             quantity=quantity,
@@ -113,19 +112,19 @@ def restore_stock(medicine_unit_id, quantity):
             import_price=None,
             active=True,
         )
-    sync_in_stock_cache(medicine_unit_id)
+    sync_in_stock_cache(product_variant_id)
 
 
-def sync_in_stock_cache(medicine_unit_id):
+def sync_in_stock_cache(product_variant_id):
     """
-    Set MedicineUnit.in_stock (default DB) to sum of remaining_quantity from Batches (store)
+    Set ProductVariant.in_stock to sum of remaining_quantity from Batches (store)
     where active, remaining_quantity > 0, expiry_date >= today.
     """
     today = timezone.now().date()
     total = (
         MedicineBatch.objects.using('store')
         .filter(
-            medicine_unit_id=medicine_unit_id,
+            product_variant_id=product_variant_id,
             active=True,
             remaining_quantity__gt=0,
             expiry_date__gte=today,
@@ -133,4 +132,4 @@ def sync_in_stock_cache(medicine_unit_id):
         .aggregate(total=models.Sum('remaining_quantity'))['total']
     )
     value = int(total) if total is not None else 0
-    MedicineUnit.objects.using('default').filter(id=medicine_unit_id).update(in_stock=value)
+    ProductVariant.objects.using('store').filter(id=product_variant_id).update(in_stock=value)

--- a/storeApp/signals/medicine_batch.py
+++ b/storeApp/signals/medicine_batch.py
@@ -10,25 +10,29 @@ from storeApp.services.stock import sync_in_stock_cache
 
 @receiver(pre_save, sender=MedicineBatch)
 def medicine_batch_pre_save(sender, instance, **kwargs):
-    """Store old medicine_unit_id on update so we can sync both units in post_save."""
+    """Store old product_variant_id on update so we can sync both variants in post_save."""
     if instance.pk:
         try:
             old = MedicineBatch.objects.using('store').get(pk=instance.pk)
-            instance._old_medicine_unit_id = old.medicine_unit_id
+            instance._old_product_variant_id = old.product_variant_id
         except MedicineBatch.DoesNotExist:
             pass
 
 
 @receiver(post_save, sender=MedicineBatch)
 def medicine_batch_post_save(sender, instance, created, **kwargs):
-    """Sync cache for the unit linked to this batch. On update, sync old unit if medicine_unit_id changed."""
-    sync_in_stock_cache(instance.medicine_unit_id)
-    if not created and getattr(instance, '_old_medicine_unit_id', None) is not None:
-        if instance._old_medicine_unit_id != instance.medicine_unit_id:
-            sync_in_stock_cache(instance._old_medicine_unit_id)
+    """Sync cache for the variant linked to this batch. On update, sync old variant if product_variant_id changed."""
+    if instance.product_variant_id:
+        sync_in_stock_cache(instance.product_variant_id)
+    
+    old_variant_id = getattr(instance, '_old_product_variant_id', None)
+    if not created and old_variant_id is not None:
+        if old_variant_id != instance.product_variant_id:
+            sync_in_stock_cache(old_variant_id)
 
 
 @receiver(post_delete, sender=MedicineBatch)
 def medicine_batch_post_delete(sender, instance, **kwargs):
-    """Sync cache for the unit that had this batch."""
-    sync_in_stock_cache(instance.medicine_unit_id)
+    """Sync cache for the variant that had this batch."""
+    if instance.product_variant_id:
+        sync_in_stock_cache(instance.product_variant_id)


### PR DESCRIPTION
Update stock management to use `ProductVariant` instead of  `MedicineUnit` and make `product_variant` foreign keys non-nullable in related models.